### PR TITLE
Provide feedback about available 'scripts/restart' commands

### DIFF
--- a/scripts/restart
+++ b/scripts/restart
@@ -7,7 +7,8 @@ CMD=$1
 
 pattern="pod|validator|exporter"
 if [[ ! $CMD =~ $pattern ]]; then
-  echo "restart: Unknown command $CMD"
+  echo "$0: Unknown command $CMD"
+  echo "Try one of: $pattern"
   exit 1
 fi
 


### PR DESCRIPTION
If you run `scripts/deploy` on its own, it'll echo back the availble commands now
