### PR TITLE
Wait 2s before attempting first validator startupProbe

### DIFF
--- a/k8s/validator.yml
+++ b/k8s/validator.yml
@@ -64,7 +64,7 @@ spec:
               command:
               - cat
               - /tmp/miner-started
-            initialDelaySeconds: 0 # probe right away. default=0
+            initialDelaySeconds: 2 # give validator container a smidge to start up. default=0
             periodSeconds: 5 # give validator **2 minutes** to start up before we kill and try again
             failureThreshold: 12 # try for 1 minute before giving up
           command: [ "/bin/ash", "-c" ]


### PR DESCRIPTION
Previously was probing immediately (0 second wait). Now will wait 2s

Should fix #27
