### PR TITLE
Output error if user needs to run Grafana tunnel

### DIFF
--- a/scripts/dashboard/download
+++ b/scripts/dashboard/download
@@ -14,9 +14,12 @@ function load_panel {
   echo "$panel"
 }
 
+# Check if you ran the tunnel before running this
+grafana_check_if_running && echo "Grafana running" || echo "Grafana not accessible; try running scripts/dashboard/monitor first"
+
 # Fetch the UID of our dashboard
 dash_name="Helium Validator Dashboard"
-response=$(grafana_api /api/search?query=$dash_name)
+response=$(grafana_api "/api/search?query=$dash_name")
 dash_uid=$(echo "$response" | jq -r -c --arg name "$dash_name" '[ .[] | select( .title | contains($name)) ][0].uid')
 
 if [[ $dash_uid == "null" ]] || [ -z "$dash_uid" ]; then
@@ -26,7 +29,7 @@ fi
 
 echo -e "Fetching latest $(label "$dash_name" $GREEN) ..."
 response=$(grafana_api /api/dashboards/uid/$dash_uid)
- 
+
 dashboard_yml=$CONFIG_PATH/validator-dashboard.yml
 dashboard=$(echo "$response" | jq -c --arg title "$dash_name" '.dashboard | .uid = null | .version = 1 | .title = $title')
 

--- a/scripts/helper
+++ b/scripts/helper
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Misc kubectl+validator helper include 
+# Misc kubectl+validator helper include
 #
 
 POD_NAME=validator
@@ -33,6 +33,11 @@ function get_miner_address {
 function is_in_consensus {
   replica=$1
   kubectl exec -it $POD_NAME-$replica -c $CONTAINER_NAME -n $NAMESPACE -- /bin/sh -c "miner info in_consensus"
+}
+
+# is the scripts/dashboard/monitor tunnel running? returns true/false
+function grafana_check_if_running {
+  (curl -s "http://localhost:${GRAFANA_PORT}/login" | grep Grafana >/dev/null)
 }
 
 function grafana_api {


### PR DESCRIPTION
Currently it just fails without telling you that you need to run `scripts/dashboard/monitor` first

I still can't quite this script to work on macOS. I suspect more Mac vs Windows bash quoting issues. I get a jq error and `No Helium dashboard found under the name 'Helium Validator Dashboard'`
