### PR TITLE
Script to explicitly connect cluster nodes

### DIFF
--- a/scripts/cluster-connect
+++ b/scripts/cluster-connect
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+addrs=$(scripts/validator addrs | grep "/ip4"); echo $addrs; echo; 
+
+validator_count=$(kubectl get pods | grep -c "validator")
+# for j in 0 1 2 3 4 5 6 7 8 9 10 11; do 
+for ((i = 0; i < validator_count; i++)); do
+  echo
+  echo "--- validator-$i ---"
+  for addr in $addrs; do 
+    kubectl exec -it "validator-$i" -c validator -- sh -c "miner peer connect $addr"
+  done
+done

--- a/scripts/validator
+++ b/scripts/validator
@@ -59,10 +59,10 @@ elif [[ $CMD == "addrs" ]]; then
   for ((i = 0; i < validator_count; i++)); do
     pod="validator-$i"
     echo; echo "Pod: $pod"
-    echo "'peer listen':"
-    kubectl exec -it $pod -c validator -- sh -c "miner peer listen --format=csv"
-    echo; echo "'peer addr':"
-    kubectl exec -it $pod -c validator -- sh -c "miner peer addr"
+    # echo "'peer listen':"
+    kubectl exec -it $pod -c validator -- sh -c "miner peer listen --format=csv | tail -n1"
+    # echo; echo "'peer addr':"
+    # kubectl exec -it $pod -c validator -- sh -c "miner peer addr"
   done
 
   


### PR DESCRIPTION
Since all the nodes are on the same LAN, it would presumably be performant for them to sync blocks. Thus they should just always try to be connected to one another

This is a rudimentary script to run `miner peer connect {ip}` on every cluster node
