### PR TITLE
Script to completely recycle local dbs for a given validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ keys.yml
 kubectl
 kubectl.sha256
 assets/logo.psd
-snapshot.bin
+snapshot.bin.gz
 scripts/keys/*
 k8s/grafana/external-dns*
 *.bak

--- a/scripts/recycle
+++ b/scripts/recycle
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+pod_id=$1
+healthy_pod_id=$2
+
+if [ -z $pod_id ] || [ -z $healthy_pod_id ]; then
+  echo "$0: you must specify a bad pod ID and a healthy pod ID as arguments"
+  exit 1
+fi
+
+echo "$(date) Starting recycle on pod $pod_id using snapshot from $healthy_pod_id ..."
+echo
+
+
+# Response must say OK not not RPC error otherwise you'll have a faulty snpashot
+echo "$(date) Downloading snapshot..."
+download=$(./scripts/snapshot download $healthy_pod_id)
+echo "download => $?"
+echo $download
+#read
+
+# Delete the data and wait for pod to reboot...
+echo "$(date) Resetting validator db..."
+reset=$(./scripts/validator reset_db $pod_id)
+echo "reset => $?"
+echo $reset
+#read
+
+# each of these steps must say OK.. need to update this script to fail if they dont.
+echo "$(date) Uploading snapshot..."
+upload=$(./scripts/snapshot upload $pod_id)
+echo "upload => $?"
+echo $upload
+#read
+
+# sometimes after importing a snapshot the resume_sync command doesnt go through and you have to tell it to resume sync again after a restart...
+echo "$(date) Resuming sync..."
+resume=$(kubectl exec -it "validator-$pod_id" -c "validator" -n "helium" -- sh -c "miner repair sync_resume")
+echo "resume => $?"
+echo $resume
+
+echo
+echo "$(date) All done"
+echo
+echo "Waiting 30s then checking block height:"
+sleep 30
+kubectl exec -it "validator-$pod_id" -c "validator" -n "helium" -- sh -c "miner info height"

--- a/scripts/snapshot
+++ b/scripts/snapshot
@@ -35,10 +35,10 @@ if [ -n "$replica_from" ]; then
 
   if [ -n "$download" ]; then
     echo; echo "$replica_from: Exporting snapshot ..."
-    kubectl exec -it "$replica_from" -c $CONTAINER -n $NAMESPACE -- sh -c "miner snapshot take /var/data/snapshot.bin"
+    kubectl exec -it "$replica_from" -c $CONTAINER -n $NAMESPACE -- sh -c "rm -f /var/data/snapshot.bin; miner snapshot take /var/data/snapshot.bin"
 
     echo "$replica_from: Downloading snapshot ..."
-    kubectl cp "$replica_from:/var/data/snapshot.bin" "$snapshot_path" -c $CONTAINER -n $NAMESPACE > /dev/null
+    kubectl cp "$replica_from:/var/data/snapshot.bin.gz" "$snapshot_path" -c $CONTAINER -n $NAMESPACE > /dev/null
   fi
 fi
 
@@ -50,7 +50,7 @@ if [ -n "$replica_to" ]; then
   kubectl exec -it "$replica_to" -c "$CONTAINER" -n "$NAMESPACE" -- sh -c "miner repair sync_pause"
 
   echo "$replica_to: Importing snapshot ..."
-  kubectl exec -it "$replica_to" -c "$CONTAINER" -n "$NAMESPACE" -- sh -c "miner snapshot load /var/data/snapshot.bin"
+  kubectl exec -it "$replica_to" -c "$CONTAINER" -n "$NAMESPACE" -- sh -c "miner snapshot load /var/data/snapshot.bin.gz"
 
   echo "$replica_to: Resuming sync ..."
   kubectl exec -it "$replica_to" -c "$CONTAINER" -n "$NAMESPACE" -- sh -c "miner repair sync_resume"

--- a/scripts/snapshot
+++ b/scripts/snapshot
@@ -5,7 +5,7 @@ CONTAINER=validator
 CMD=$1
 replica_from=
 replica_to=
-snapshot_path=./snapshot.bin
+snapshot_path=./snapshot.bin.gz
 
 if [[ "$CMD" == "download" || "$CMD" == "take" ]]; then
   replica_from="validator-$2"


### PR DESCRIPTION
Restart with totally fresh database files

Helps solve for the disk-usage-grows-forever issue

- downloads snapshot locally
- resets db files on given validator
- uploads new snapshot
- attempts to verify steps, but does a poor job
