### PR TITLE
Open up port 8080, for light hotspots

### DIFF
--- a/k8s/helium-validators-configmap.yml
+++ b/k8s/helium-validators-configmap.yml
@@ -4,16 +4,23 @@ metadata:
   name: validator
 data:
   validator-setup.sh: |
-    # Wait for port to be available via 
-    while [ -z "$NAT_EXTERNAL_PORT" ]; do
+    # Wait for port to be available via
+    while [ -z "$GRPC_PORT" ]; do
       echo "Searching for port...";
       port=$(cat /etc/podinfo/annotations | grep "k8s/2154" | grep -oE "\"[0-9]+\"" | grep -oE "[0-9]+" | xargs);
       if [ -n "$port" ]; then
         export NAT_EXTERNAL_IP=$(wget -qO- ifconfig.me);
         export NAT_EXTERNAL_PORT=$port;
-        echo "Port found! NAT_EXTERNAL_IP=$NAT_EXTERNAL_IP NAT_EXTERNAL_PORT=$NAT_EXTERNAL_PORT";
+        echo "2154 port found! NAT_EXTERNAL_IP=$NAT_EXTERNAL_IP NAT_EXTERNAL_PORT=$NAT_EXTERNAL_PORT";
         echo "export NAT_EXTERNAL_IP=$NAT_EXTERNAL_IP" >> ~/.profile;
         echo "export NAT_EXTERNAL_PORT=$NAT_EXTERNAL_PORT" >> ~/.profile;
+      fi;
+
+      port=$(cat /etc/podinfo/annotations | grep "k8s/8080" | grep -oE "\"[0-9]+\"" | grep -oE "[0-9]+" | xargs);
+      if [ -n "$port" ]; then
+        export GRPC_PORT=$port;
+        echo "8080 port found! GRPC_PORT=$GRPC_PORT";
+        echo "export GRPC_PORT=$GRPC_PORT" >> ~/.profile;
         break;
       fi;
       sleep 2;
@@ -106,7 +113,7 @@ data:
           echo "[Version] Latest $latest_version_sha";
           echo "[Version] Current $current_version_sha ($container_version)";
           echo "[Version] Shutting down validator";
-          
+
           tail_process=$(pgrep -f "tail -F /var/data");
           kill "$tail_process";
           exit 1;

--- a/k8s/validator.yml
+++ b/k8s/validator.yml
@@ -17,7 +17,7 @@ spec:
       labels:
         name: validator
         app: validator # being used by ServiceMonitor; could we target 'name' instead?
-        dynamic-hostports: '2154,8080' # must be a string. Split multiple ports with '.'
+        dynamic-hostports: '2154.8080' # must be a string. Split multiple ports with '.'
     spec:
       shareProcessNamespace: true # otherwise you'll end up with mountains of zombie processes
       containers:

--- a/k8s/validator.yml
+++ b/k8s/validator.yml
@@ -17,7 +17,7 @@ spec:
       labels:
         name: validator
         app: validator # being used by ServiceMonitor; could we target 'name' instead?
-        dynamic-hostports: '2154' # must be a string. Split multiple ports with '.'
+        dynamic-hostports: '2154,8080' # must be a string. Split multiple ports with '.'
     spec:
       shareProcessNamespace: true # otherwise you'll end up with mountains of zombie processes
       containers:
@@ -90,6 +90,7 @@ spec:
           ports:
             - containerPort: 2154
             - containerPort: 4467
+            - containerPort: 8080
           volumeMounts:
             - name: validator-vol
               mountPath: /var/data


### PR DESCRIPTION
Exposes port `8080` and sets `GRPC_PORT` to the external dynamic port
```sh
/opt/miner$ cat ~/.profile
export NAT_EXTERNAL_IP=165.232.141.66
export NAT_EXTERNAL_PORT=30351
export GRPC_PORT=31343
```

[thread in helium discord](https://discord.com/channels/404106811252408320/857353417739730954/969339293271203860)